### PR TITLE
Fixed TrendLeaderboard serialization

### DIFF
--- a/Ducksboard/Objects/TrendLeaderboard.cs
+++ b/Ducksboard/Objects/TrendLeaderboard.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Ducksboard.Objects
 {
+    [DataContract]
     public class TrendLeaderboard : DucksboardObjectBase
     {
         public TrendLeaderboard()
@@ -9,15 +11,16 @@ namespace Ducksboard.Objects
             Value = new Payload();
         }
 
+        [DataMember(Name = "value")]
         public Payload Value { get; set; }
 
         public TrendLeaderboard Add(string name, string trend, params decimal[] values)
         {
             var item = new Payload.BoardItem
-                           {
-                               Name = name,
-                               Trend = trend,
-                           };
+            {
+                Name = name,
+                Trend = trend,
+            };
 
             if (values != null)
                 foreach (decimal value in values)
@@ -28,6 +31,7 @@ namespace Ducksboard.Objects
             return this;
         }
 
+        [DataContract]
         public class Payload
         {
             public Payload()
@@ -35,8 +39,10 @@ namespace Ducksboard.Objects
                 Board = new List<BoardItem>();
             }
 
+            [DataMember(Name = "board")]
             public IList<BoardItem> Board { get; set; }
 
+            [DataContract]
             public class BoardItem
             {
                 public BoardItem()
@@ -44,8 +50,13 @@ namespace Ducksboard.Objects
                     Values = new List<decimal>();
                 }
 
+                [DataMember(Name = "name")]
                 public string Name { get; set; }
+
+                [DataMember(Name = "values")]
                 public IList<decimal> Values { get; set; }
+
+                [DataMember(Name = "trend", EmitDefaultValue = false)]
                 public string Trend { get; set; }
             }
         }


### PR DESCRIPTION
Hi,

I played some more with Ducksboard and this library and found out the TrendLeaderboard API wasn't working.
It was due to serialization attributes missing in the model class.
The members would be serialized with their default names (PascalCase) and since Ducksboard requires lowercase JSON attributes, the values wouldn't be picked up.
I have tested these changes in my app for a few days now and it's been working fine.

Cheers
Xavier
