### PR TITLE
Added Pin object for dealing with maps! 

### DIFF
--- a/Ducksboard.Tests/Ducksboard.Tests.csproj
+++ b/Ducksboard.Tests/Ducksboard.Tests.csproj
@@ -63,7 +63,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ducksboard\Ducksboard.csproj">
       <Project>{96A6B30E-DE64-4F5F-B2B1-099433DB7549}</Project>

--- a/Ducksboard.Tests/Objects/ObjectTests.cs
+++ b/Ducksboard.Tests/Objects/ObjectTests.cs
@@ -209,4 +209,23 @@ namespace Ducksboard.Tests.Objects
             result.Should().NotBeNullOrEmpty();
         }
     }
+
+    public class PinTests : SerializationTest
+    {
+        [Fact]
+        public void Can_serialize_pin_objects()
+        {
+            var target = new Pin();
+
+            target.Value.Color = "#C11F70";
+            target.Value.Latitude = 51.5033630m;
+            target.Value.Longitude = -0.1276250m;
+            target.Value.Size = 1;
+            target.Value.Value = 3.2m;
+            target.Value.Info = "details!";
+
+            string result = Serializer.Serialize(target);
+            result.Should().NotBeNullOrEmpty();
+        }
+    }
 }

--- a/Ducksboard/Ducksboard.csproj
+++ b/Ducksboard/Ducksboard.csproj
@@ -51,6 +51,7 @@
     <Compile Include="DucksboardClient.cs" />
     <Compile Include="Objects\Completion.cs" />
     <Compile Include="Objects\Dashboard.cs" />
+    <Compile Include="Objects\Pin.cs" />
     <Compile Include="Objects\Slot.cs" />
     <Compile Include="Objects\WidgetProperties.cs" />
     <Compile Include="Objects\Status.cs" />

--- a/Ducksboard/Objects/Pin.cs
+++ b/Ducksboard/Objects/Pin.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.Serialization;
+
+namespace Ducksboard.Objects
+{
+
+    /// <summary>
+    /// This will be submitted to the ducksboard API project.
+    /// </summary>
+    [DataContract]
+    public class Pin : DucksboardObjectBase        
+    {
+        public Pin()
+        {
+            Value = new Payload();
+        }
+
+        [DataMember(Name = "value")]
+        public Payload Value { get; set; }
+
+        [DataContract]
+        public class Payload
+        {
+            [DataMember(Name = "latitude", EmitDefaultValue = false)]
+            public decimal Latitude { get; set; }
+
+            [DataMember(Name = "longitude", EmitDefaultValue = false)]
+            public decimal Longitude { get; set; }
+
+            [DataMember(Name = "ip", EmitDefaultValue = false)]
+            public string IP { get; set; }
+
+            [DataMember(Name = "value", EmitDefaultValue = false)]
+            public decimal Value { get; set; }
+
+            [DataMember(Name = "size", EmitDefaultValue = false)]
+            public int Size { get; set; }
+
+            [DataMember(Name = "info", EmitDefaultValue = false)]
+            public string Info { get; set; }
+
+            [DataMember(Name = "color", EmitDefaultValue = false)]
+            public string Color { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I was impressed by your .Net API, it made getting started with Ducksboard quick and fun! Eventually I needed to make a map, and in the docs in says that you should use the Numbers object. I was unable to make that work because the API calls for a more complex structure than that. So I dove into your repo and created a new Pin object! 
- I did my best to follow your conventions and modeled this on the Timeline object. 
- I also did my best to fully implement all the options defined in the Ducksboard API.
- I added an xunit integration test for this and verified that it passes
- I am also using this in production. 

Please consider merging this in. Thanks!
